### PR TITLE
Load data from the AP API for the states export

### DIFF
--- a/enip_backend/ingest/apapi.py
+++ b/enip_backend/ingest/apapi.py
@@ -7,10 +7,11 @@ from ..enip_common.config import AP_API_KEY, ELECTION_DATE, INGEST_TEST_DATA
 from ..export.helpers import sqlrecord_from_dict
 
 OFFICE_IDS = ["P", "S", "H"]
-RETURN_LEVELS = {"national", "state", "district"}
 
 
-def ingest_ap(cursor, ingest_id, save_to_db):
+def ingest_ap(
+    cursor, ingest_id, save_to_db, return_levels={"national", "state", "district"}
+):
     # Make the API request. We need to request both reporting-unit-level results,
     # which gives us everything except NE/ME congressional districts, and
     # district results for those few results.
@@ -58,7 +59,7 @@ def ingest_ap(cursor, ingest_id, save_to_db):
             if save_to_db:
                 writer.writerow(row.values())
 
-            if row["level"] in RETURN_LEVELS:
+            if row["level"] in return_levels:
                 return_data.append(sqlrecord_from_dict(row))
             n_rows += 1
 

--- a/enip_backend/lambda_handlers.py
+++ b/enip_backend/lambda_handlers.py
@@ -1,8 +1,11 @@
+from datetime import datetime, timezone
+
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 from .enip_common import config
-from .export.run import export_all_states, export_national, get_latest_ingest
+from .export.run import export_all_states, export_national
+from .ingest.apapi import ingest_ap
 from .ingest.run import ingest_all
 
 if config.SENTRY_DSN:
@@ -21,8 +24,11 @@ def run(event, context):
 
 
 def run_states(event, context):
-    ingest_id, ingest_dt = get_latest_ingest()
-    export_all_states(ingest_id, ingest_dt, ingest_dt.strftime("%Y%m%d%H%M%S"))
+    ingest_dt = datetime.now(tz=timezone.utc)
+    ap_data = ingest_ap(
+        cursor=None, ingest_id=-1, save_to_db=False, return_levels={"county"}
+    )
+    export_all_states(ap_data, ingest_dt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With the AP data not being written to the database on every run, we have to rework the states export a bit so that it makes an AP API call to load data rather than trying to load from the DB (because the most recent ingest run will only have data once every 15 minutes)