### PR TITLE
Fix some bugs with sheets sync; use sheets data in national export

### DIFF
--- a/enip_backend/enip_common/states.py
+++ b/enip_backend/enip_common/states.py
@@ -52,9 +52,9 @@ STATES = {
     "WY",
 }
 
-DISTRICTS = {"ME-1", "ME-2", "NE-1", "NE-2", "NE-3"}
+DISTRICTS = {"ME-01", "ME-02", "NE-01", "NE-02", "NE-03"}
 
-DISTRICTS_BY_STATE = {"ME": {"ME-1", "ME-2"}, "NE": {"NE-1", "NE-2", "NE-3"}}
+DISTRICTS_BY_STATE = {"ME": {"ME-01", "ME-02"}, "NE": {"NE-01", "NE-02", "NE-03"}}
 
 SENATE_SPECIALS = {"GA-S"}
 
@@ -62,4 +62,43 @@ SENATE_SPECIALS_BY_STATE = {"GA": {"GA-S"}}
 
 AT_LARGE_HOUSE_STATES = {"AK", "DE", "MT", "ND", "SD", "VT", "WY"}
 
+PRESIDENTIAL_REPORTING_UNITS = STATES | DISTRICTS
 ALL_REPORTING_UNITS = STATES | DISTRICTS | SENATE_SPECIALS
+
+SENATE_RACES = {
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CO",
+    "DE",
+    "GA",
+    "GA-S",
+    "ID",
+    "IL",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MT",
+    "NE",
+    "NH",
+    "NJ",
+    "NM",
+    "NC",
+    "OK",
+    "OR",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "VA",
+    "WV",
+    "WY",
+}

--- a/enip_backend/export/helpers.py
+++ b/enip_backend/export/helpers.py
@@ -268,4 +268,3 @@ def load_calls() -> Calls:
             calls["P"][record.state] = record.published
 
     return calls
-

--- a/enip_backend/export/helpers.py
+++ b/enip_backend/export/helpers.py
@@ -230,3 +230,42 @@ def load_election_results(
 
         for record in cursor:
             yield record
+
+
+Comments = Dict[str, Dict[str, structs.Comment]]
+
+
+def load_comments() -> Comments:
+    comments: Comments = {"P": {}, "S": {}, "H": {}}
+    with get_cursor() as cursor:
+        cursor.execute("SELECT * FROM comments ORDER BY ts DESC")
+
+        for record in cursor:
+            office = comments[record.office_id]
+            office[record.race] = structs.Comment(
+                timestamp=record.ts,
+                author=record.submitted_by,
+                title=record.title,
+                body=record.body,
+            )
+
+    return comments
+
+
+Calls = Dict[str, Dict[str, bool]]
+
+
+def load_calls() -> Calls:
+    calls: Calls = {"P": {}, "S": {}}
+
+    with get_cursor() as cursor:
+        cursor.execute("SELECT * FROM senate_calls")
+        for record in cursor:
+            calls["S"][record.state] = record.published
+
+        cursor.execute("SELECT * FROM president_calls")
+        for record in cursor:
+            calls["P"][record.state] = record.published
+
+    return calls
+

--- a/enip_backend/export/national.py
+++ b/enip_backend/export/national.py
@@ -1,6 +1,6 @@
+import logging
 from datetime import datetime
 from typing import Any, Iterable, List
-import logging
 
 from ddtrace import tracer
 
@@ -10,10 +10,10 @@ from .helpers import (
     HistoricalResults,
     SQLRecord,
     handle_candidate_results,
+    load_calls,
+    load_comments,
     load_election_results,
     load_historicals,
-    load_comments,
-    load_calls,
 )
 
 

--- a/enip_backend/ingest/run.py
+++ b/enip_backend/ingest/run.py
@@ -1,6 +1,8 @@
 import logging
 
 from ..enip_common.pg import get_cursor
+from ..enip_common.states import SENATE_RACES, PRESIDENTIAL_REPORTING_UNITS, DISTRICTS
+
 from .apapi import ingest_ap
 from .ingest_run import insert_ingest_run
 
@@ -13,7 +15,7 @@ def _calls_update_stmt(table):
     VALUES (%s, %s, NOW())
     ON CONFLICT (state) DO UPDATE
     SET (ap_call, ap_called_at) = (EXCLUDED.ap_call, NOW())
-    WHERE {table}.ap_call != EXCLUDED.ap_call
+    WHERE {table}.ap_call IS DISTINCT FROM EXCLUDED.ap_call
     """
 
 
@@ -23,21 +25,42 @@ def update_senate_calls(cursor, ingest_data):
             return "GA-S"
         return record.statepostal
 
-    winners = [
-        (extract_state(record), record.party)
-        for record in ingest_data
-        if record.officeid == "S" and record.level == "state" and record.winner
-    ]
-    cursor.executemany(_calls_update_stmt("senate_calls"), winners)
+    winners = {state: None for state in SENATE_RACES}
+    for record in ingest_data:
+        if record.officeid == "S" and record.level == "state" and record.winner:
+            winners[extract_state(record)] = record.party
+
+    cursor.executemany(
+        _calls_update_stmt("senate_calls"), [(k, v) for k, v in winners.items()]
+    )
 
 
 def update_president_calls(cursor, ingest_data):
-    winners = [
-        (record.statepostal, record.party)
-        for record in ingest_data
-        if record.officeid == "P" and record.level == "state" and record.winner
-    ]
-    cursor.executemany(_calls_update_stmt("president_calls"), winners)
+    def extract_state(record):
+        if record.level == "district":
+            if record.reportingunitname == "At Large":
+                return record.statepostal
+            elif record.reportingunitname == "District 1":
+                return f"{record.statepostal}-01"
+            elif record.reportingunitname == "District 2":
+                return f"{record.statepostal}-02"
+            elif record.reportingunitname == "District 3":
+                return f"{record.statepostal}-03"
+
+        return record.statepostal
+
+    winners = {state: None for state in PRESIDENTIAL_REPORTING_UNITS}
+    for record in ingest_data:
+        if (
+            record.officeid == "P"
+            and record.level in ("state", "district")
+            and record.winner
+        ):
+            winners[extract_state(record)] = record.party
+
+    cursor.executemany(
+        _calls_update_stmt("president_calls"), [(k, v) for k, v in winners.items()]
+    )
 
 
 def ingest_all(force_save=False):

--- a/enip_backend/lambda_handlers.py
+++ b/enip_backend/lambda_handlers.py
@@ -56,6 +56,6 @@ def run_sync_comments_gsheet(event, context):
 
 if __name__ == "__main__":
     run(None, None)
-    run_states(None, None)
+    # run_states(None, None)
     run_sync_calls_gsheet(None, None)
     run_sync_comments_gsheet(None, None)

--- a/enip_backend/lambda_handlers.py
+++ b/enip_backend/lambda_handlers.py
@@ -56,6 +56,6 @@ def run_sync_comments_gsheet(event, context):
 
 if __name__ == "__main__":
     run(None, None)
-    # run_states(None, None)
+    run_states(None, None)
     run_sync_calls_gsheet(None, None)
     run_sync_comments_gsheet(None, None)


### PR DESCRIPTION
- Fix a bug in the upsert logic. In SQL, `NULL != NULL` evaluates, confusingly, to `NULL` (https://www.postgresql.org/docs/9.1/functions-comparison.html) so we need to use `IS DISTINCT FROM`.

- Handle un-calling races when updating the DB after ingest

- Handle CD results in ME and NE when handling race calls

- Use the race calls and comments when generating the national summary